### PR TITLE
Add ReadFile functionality

### DIFF
--- a/examples/sample-script.js
+++ b/examples/sample-script.js
@@ -9,6 +9,13 @@ export default function () {
     // Write/append string to file
     file.writeString(filepath, 'New file. First line.\n');
     file.appendString(filepath, `Second line. VU: ${__VU}  -  ITER: ${__ITER}`);
+    const fileContet = file.readFile(filepath);
+    
+    check(fileContet, {
+        "file content is correct": (content) =>
+          content.includes("New file. First line.") &&
+          content.includes(`Second line. VU: ${__VU}  -  ITER: ${__ITER}`),
+    });
 
     // Remove rows from text file/clear file content/delete file
     file.removeRowsBetweenValues(filepath, 2, 2);

--- a/file.go
+++ b/file.go
@@ -6,6 +6,7 @@ package file
 
 import (
 	"bufio"
+	"io"
 	"os"
 
 	"go.k6.io/k6/js/modules"
@@ -130,4 +131,20 @@ func (*FILE) RemoveRowsBetweenValues(path string, start, end int) error {
 		return err
 	}
 	return nil
+}
+
+// ReadFile reads the contents of a file and returns it as a string
+func (*FILE) ReadFile(path string) (string, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return "", err
+	}
+	defer f.Close()
+
+	// Read the file contents
+	content, err := io.ReadAll(f)
+	if err != nil {
+		return "", err
+	}
+	return string(content), nil
 }


### PR DESCRIPTION
Fixes #13 

The default method that k6 provides for reading files is the `open()` function. However, this function is limited to the init context, meaning files can only be read during the script's initialization phase. This restriction makes it unsuitable for scenarios where files need to be read dynamically during test execution.

I created a custom `readFile` function in your Go-based extension to address scenarios where dynamic file reading is required during the test execution phase.

Also, I have enhanced the `sample-script.js` to demonstrate the usage of this.